### PR TITLE
fix: accept colon in aws profile names

### DIFF
--- a/src/main/java/net/coderazzi/aws_codeartifact_maven/utils/AWSProfileHandler.java
+++ b/src/main/java/net/coderazzi/aws_codeartifact_maven/utils/AWSProfileHandler.java
@@ -20,12 +20,12 @@ public class AWSProfileHandler {
 
     public static final String DEFAULT_PROFILE = "default";
     // https://docs.aws.amazon.com/IAM/latest/APIReference/API_CreateInstanceProfile.html
-    // Profile name pattern: [\w+=,.@-]+
+    // Profile name pattern: [\w+=,.@:-]+
     private static final Pattern configPattern =
-            Pattern.compile("^\\s*\\[\\s*profile\\s+([\\w+=,.@-]+)\\s*]\\s*$",
+            Pattern.compile("^\\s*\\[\\s*profile\\s+([\\w+=,.@:-]+)\\s*]\\s*$",
             Pattern.CASE_INSENSITIVE);
     private static final Pattern credentialsPattern =
-            Pattern.compile("^\\s*\\[\\s*([\\w+=,.@-]+)\\s*]\\s*$",
+            Pattern.compile("^\\s*\\[\\s*([\\w+=,.@:-]+)\\s*]\\s*$",
             Pattern.CASE_INSENSITIVE);
 
     public static Set<String> getDefaultProfiles() {


### PR DESCRIPTION
Context:
The plugin does not find any profile because my aws profiles have colons in them.

Fix:
Add : in the regex character class.

Test:
Ran this in a sandbox, and I was able to correctly generate the token.